### PR TITLE
Fixing bug in i2c read chipAddr. Cleanup in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ target_link_libraries(oled_display_node
     ${catkin_LIBRARIES}
 )
 
-add_dependencies(oled_display_node oled_display_node_generate_messages_cpp)
+add_dependencies(oled_display_node ${PROJECT_NAME}_generate_messages_cpp)
 
 #############
 ## Install ##

--- a/src/oled_display_node.cpp
+++ b/src/oled_display_node.cpp
@@ -281,7 +281,7 @@ static int i2c_BufferRead(const char *i2cDevFile, uint8_t i2c7bitAddr,
       goto exitWithFileClose;
     }
 
-    if (chipRegAddr < 0) {     // Suppress reg address if negative value was used
+    if (chipRegAddr >= 0) {     // Only write reg address if negative value was used
       buf[0] = (uint8_t)(chipRegAddr);          // Internal chip register address
       if ((write(fd, buf, 1)) != 1) {           // Write both bytes to the i2c port
         retCode = -4;


### PR DESCRIPTION
Fix bug where we were backwards in suppression of internal chip register write.  Because this display has only one readback register it perhaps why it worked with this bug before now.    Also cleanup in CMakeLists.txt so instead of hard coded project name we specify PROJECT_NAME in add_dependencies directive