### PR TITLE
Oled fixes feb2022 - Battery charge and motor power on off shown

### DIFF
--- a/src/oled_display_node.cpp
+++ b/src/oled_display_node.cpp
@@ -393,7 +393,7 @@ int dispOled_detectDisplayType(std::string devName, uint8_t i2c7bitAddr, int *di
 
     // We have seen incorrect values read sometimes and because this chip relies on
     // a status register in the SH1106 we better read a few times and 'vote'
-    for (i=0 ; i < 3 ; i++) {
+    for (i=0 ; i < 5 ; i++) {
         // Read the status register at chip addr 0 to decide on chip type - set flag to true
         retCount = i2c_read(&device[0], i2c7bitAddr, &buf[0], 1, 0x00, true);
         if (retCount < 0) {
@@ -417,7 +417,7 @@ int dispOled_detectDisplayType(std::string devName, uint8_t i2c7bitAddr, int *di
                 vote1106++;
             }
         }
-        usleep(25000);
+        usleep(30000);
     }
 
     // count the votes and set display type
@@ -900,9 +900,9 @@ int main(int argc, char **argv)
         // If you change the text, use same number of chars so display does not move around on the line
         std::stringstream powStream;
 	if (g_motorPowerActive > 0) {
-            powStream <<   "  ON";
+            powStream <<   " ON";
         }else {
-            powStream <<   " OFF";
+            powStream <<   "OFF";
         }
         std::string motPowerText = "Mot Power " + powStream.str();
         dispError |= dispOled_writeText(&g_oledDisplayCtx, DISP_LINE_MOTOR_POWER, 1, DISP_TEXT_START_MODE, motPowerText.c_str());

--- a/src/oled_display_node.cpp
+++ b/src/oled_display_node.cpp
@@ -785,11 +785,17 @@ void batteryStateApiCallback(const sensor_msgs::BatteryState::ConstPtr& msg)
  */
 void motorPowerActiveApiCallback(const std_msgs::Bool::ConstPtr& msg)
 {
+  int32_t newPowerState;
   if (msg->data) {
-    g_motorPowerActive = 1;
+    newPowerState = 1;
   } else {
-    g_motorPowerActive = 0;
+    newPowerState = 0;
   }
+  if (newPowerState != g_motorPowerActive) {
+    ROS_INFO("%s Motor power active went from %d to %d", THIS_NODE_NAME, g_motorPowerActive, newPowerState);
+  }
+
+  g_motorPowerActive = newPowerState;
   return;
 }
 
@@ -893,7 +899,7 @@ int main(int argc, char **argv)
 
         // If you change the text, use same number of chars so display does not move around on the line
         std::stringstream powStream;
-	if (g_motorPowerActive > 0 >= BAT_CHARGING_LEVEL) {
+	if (g_motorPowerActive > 0) {
             powStream <<   "  ON";
         }else {
             powStream <<   " OFF";


### PR DESCRIPTION
Several fixes and and additions long overdue

- When bat voltage > 27V at the end say  CHRG for charging
- Different and more robust use of the 'ip addr' and better logic to get IP address right.
- Show 'Mot Power  OFF'  or  ON based on state of estop switch
- Attempt for more robust display type determination using best of 5 simple approach

This would have been nice to put firmware rev on there too but enough for this pull request already. 