### PR TITLE
added sensor_msgs to package xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -12,6 +12,7 @@
   <depend>roscpp</depend>
   <depend>rospy</depend>
   <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
   <build_depend>message_generation</build_depend>
   <build_export_depend>message_runtime</build_export_depend>
   <exec_depend>message_runtime</exec_depend>


### PR DESCRIPTION
We triggered a new apt release with @rohbotics on this and this error came up:
```
/build/ros-noetic-oled-display-node-1.1.0/src/oled_display_node.cpp:136:10: fatal error: sensor_msgs/BatteryState.h: No such file or directory
  136 | #include <sensor_msgs/BatteryState.h>
```
Which probably means you did not include `sensor_msgs` into your `package.xml`

this is a fix for https://github.com/UbiquityRobotics/pi_image2/issues/32#issuecomment-1050007481